### PR TITLE
fix: tsx and css

### DIFF
--- a/components/galleries/galleries.css
+++ b/components/galleries/galleries.css
@@ -75,6 +75,8 @@
 }
 
 .woh__bread-stack-button {
+    position: relative;
+    z-index: 101;
     flex-grow: 1;
     cursor: pointer;
 }

--- a/components/galleries/image-card-stacked.tsx
+++ b/components/galleries/image-card-stacked.tsx
@@ -15,7 +15,9 @@ export default function ImageCardStacked(props: StackedCardProps) {
   const [activeIndex, setActiveIndex] = useState<number | null>(defaultActiveIndex);
 
   const clickHandler = (index: number) => {
-    setActiveIndex((prevIndex) => (prevIndex === index ? null : index));
+    setActiveIndex((prevIndex) => {
+      return (prevIndex === index) ? 0 : index
+    });
   };
 
   const indexDecrementer = () => (activeIndex === 0)


### PR DESCRIPTION
- Changed the ternary in the callback passed to setActiveIndex to no longer return null
- Updated bread stack button to position: relative and z-index: 100
- Now bread stack button is always above the cards.